### PR TITLE
Add Guzzle requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "homepage": "https://github.com/laveto/laravelmultivers",
     "keywords": ["Laravel", "LaravelMultivers", "Multivers", "connector"],
     "require": {
-        "illuminate/support": "~5"
+        "illuminate/support": "~5",
+        "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.0",


### PR DESCRIPTION
In a fresh Laravel installation I'd get a GuzzleHttp Client not found error without this dependency in the composer.json.